### PR TITLE
feat: support customization of sharding labels

### DIFF
--- a/pkg/apis/ctrlmesh/types.go
+++ b/pkg/apis/ctrlmesh/types.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package ctrlmesh
 
+import (
+	"flag"
+)
+
 // Environments
 const (
 	EnvEnableWebhookServer     = "ENABLE_WEBHOOK_SERVER"
@@ -28,9 +32,6 @@ const (
 // Labels
 const (
 	CtrlmeshControlPrefix                 = "ctrlmesh.kusionstack.io/"
-	CtrlmeshShardHashKey                  = "ctrlmesh.kusionstack.io/shard-hash"
-	CtrlmeshControlKey                    = "ctrlmesh.kusionstack.io/control"
-	CtrlmeshNamespaceKey                  = "ctrlmesh.kusionstack.io/namespace"
 	CtrlmeshIgnoreWebhookLabel            = "ctrlmesh.kusionstack.io/ignore-webhook"
 	CtrlmeshIgnoreValidateLabel           = "ctrlmesh.kusionstack.io/ignore-validate"
 	CtrlmeshDefaultReplicasLabel          = "ctrlmesh.kusionstack.io/default-replicas"
@@ -62,7 +63,42 @@ const (
 	ProtectFinalizer = "finalizer.ctrlmesh.kusionstack.io/protected"
 )
 
-// Name
-const (
-	ShardingConfigMapName = "ctrlmesh-sharding-config"
+var (
+	shardHashLabel   string
+	meshControlLabel string
+	namespaceLabel   string
 )
+
+func init() {
+	flag.StringVar(&shardHashLabel, "label-shard-hash", "ctrlmesh.kusionstack.io/shard-hash", "The sharding hash label.")
+	flag.StringVar(&meshControlLabel, "label-mesh-control", "ctrlmesh.kusionstack.io/control", "The controller mesh control label.")
+	flag.StringVar(&namespaceLabel, "label-namespace", "ctrlmesh.kusionstack.io/namespace", "The namespace label.")
+}
+
+func ShardHashLabel() string {
+	return shardHashLabel
+}
+
+func MeshControlLabel() string {
+	return meshControlLabel
+}
+
+func NamespaceShardLabel() string {
+	return namespaceLabel
+}
+
+func IsControlledByMesh(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+	val, ok := labels[MeshControlLabel()]
+	return ok && val == "true"
+}
+
+func ShouldSyncLabels() []string {
+	return []string{
+		ShardHashLabel(),
+		MeshControlLabel(),
+		NamespaceShardLabel(),
+	}
+}

--- a/pkg/cmd/manager/main.go
+++ b/pkg/cmd/manager/main.go
@@ -52,8 +52,9 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 
-	restConfigQPS   = flag.Int("rest-config-qps", 30, "QPS of rest config.")
-	restConfigBurst = flag.Int("rest-config-burst", 50, "Burst of rest config.")
+	restConfigQPS       = flag.Int("rest-config-qps", 30, "QPS of rest config.")
+	restConfigBurst     = flag.Int("rest-config-burst", 50, "Burst of rest config.")
+	enablePatchRunnable = flag.Bool("enable-patch-runnable", true, "")
 )
 
 func init() {
@@ -161,10 +162,11 @@ func main() {
 			setupLog.Error(err, "unable to create controller", "controller", "CircuitBreaker")
 			os.Exit(1)
 		}
-
-		if err = patchrunnable.SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create runnable", "runnable", "PatchRunnable")
-			os.Exit(1)
+		if *enablePatchRunnable {
+			if err = patchrunnable.SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create runnable", "runnable", "PatchRunnable")
+				os.Exit(1)
+			}
 		}
 	}()
 

--- a/pkg/manager/controllers/patchrunnable/labelpatch_runnable.go
+++ b/pkg/manager/controllers/patchrunnable/labelpatch_runnable.go
@@ -295,25 +295,25 @@ func updateLabel(ns *v1.Namespace) (bool, error) {
 
 	nsHash := strconv.Itoa(rand.Hash(ns.Name, constants.DefaultShardingSize))
 
-	if _, ok := ns.Labels[ctrlmesh.CtrlmeshControlKey]; !ok {
-		if _, exist := ns.Labels[ctrlmesh.CtrlmeshShardHashKey]; exist {
-			return false, fmt.Errorf("label %s already exist but can not find %s", ctrlmesh.CtrlmeshShardHashKey, ctrlmesh.CtrlmeshControlKey)
+	if _, ok := ns.Labels[ctrlmesh.MeshControlLabel()]; !ok {
+		if _, exist := ns.Labels[ctrlmesh.ShardHashLabel()]; exist {
+			return false, fmt.Errorf("label %s already exist but can not find %s", ctrlmesh.ShardHashLabel(), ctrlmesh.MeshControlLabel())
 		}
-		if _, exist := ns.Labels[ctrlmesh.CtrlmeshNamespaceKey]; exist {
-			return false, fmt.Errorf("label %s already exist but can not find %s", ctrlmesh.CtrlmeshNamespaceKey, ctrlmesh.CtrlmeshControlKey)
+		if _, exist := ns.Labels[ctrlmesh.NamespaceShardLabel()]; exist {
+			return false, fmt.Errorf("label %s already exist but can not find %s", ctrlmesh.NamespaceShardLabel(), ctrlmesh.MeshControlLabel())
 		}
-		ns.Labels[ctrlmesh.CtrlmeshControlKey] = "true"
-		ns.Labels[ctrlmesh.CtrlmeshNamespaceKey] = ns.Name
-		ns.Labels[ctrlmesh.CtrlmeshShardHashKey] = nsHash
+		ns.Labels[ctrlmesh.MeshControlLabel()] = "true"
+		ns.Labels[ctrlmesh.NamespaceShardLabel()] = ns.Name
+		ns.Labels[ctrlmesh.ShardHashLabel()] = nsHash
 		return true, nil
 	} else {
-		if val, exist := ns.Labels[ctrlmesh.CtrlmeshShardHashKey]; !exist || nsHash != val {
-			ns.Labels[ctrlmesh.CtrlmeshNamespaceKey] = ns.Name
-			ns.Labels[ctrlmesh.CtrlmeshShardHashKey] = nsHash
+		if val, exist := ns.Labels[ctrlmesh.ShardHashLabel()]; !exist || nsHash != val {
+			ns.Labels[ctrlmesh.NamespaceShardLabel()] = ns.Name
+			ns.Labels[ctrlmesh.ShardHashLabel()] = nsHash
 			return true, nil
 		}
-		if val, exist := ns.Labels[ctrlmesh.CtrlmeshNamespaceKey]; !exist || val != ns.Name {
-			ns.Labels[ctrlmesh.CtrlmeshNamespaceKey] = ns.Name
+		if val, exist := ns.Labels[ctrlmesh.NamespaceShardLabel()]; !exist || val != ns.Name {
+			ns.Labels[ctrlmesh.NamespaceShardLabel()] = ns.Name
 			return true, nil
 		}
 	}

--- a/pkg/manager/controllers/shardingconfigserver/auto_sharding.go
+++ b/pkg/manager/controllers/shardingconfigserver/auto_sharding.go
@@ -185,14 +185,14 @@ func genCanaryLimits(canaryConfig *ctrlmeshv1alpha1.CanaryConfig, originLimiter 
 		}
 		if len(canaryConfig.InNamespaces) > 0 {
 			newSel.Selector.MatchExpressions = append(newSel.Selector.MatchExpressions, metav1.LabelSelectorRequirement{
-				Key:      ctrlmesh.CtrlmeshNamespaceKey,
+				Key:      ctrlmesh.NamespaceShardLabel(),
 				Operator: metav1.LabelSelectorOpIn,
 				Values:   canaryConfig.InNamespaces,
 			})
 		}
 		if len(canaryConfig.InShardHash) > 0 {
 			newSel.Selector.MatchExpressions = append(newSel.Selector.MatchExpressions, metav1.LabelSelectorRequirement{
-				Key:      ctrlmesh.CtrlmeshShardHashKey,
+				Key:      ctrlmesh.ShardHashLabel(),
 				Operator: metav1.LabelSelectorOpIn,
 				Values:   canaryConfig.InShardHash,
 			})
@@ -214,20 +214,20 @@ func genShardingGlobalLimits(root *ctrlmeshv1alpha1.ShardingConfig, batch []stri
 		}
 		if canaryConfig != nil && len(canaryConfig.InNamespaces) > 0 && *root.Spec.Root.Canary.Replicas > 0 {
 			newSel.Selector.MatchExpressions = append(newSel.Selector.MatchExpressions, metav1.LabelSelectorRequirement{
-				Key:      ctrlmesh.CtrlmeshNamespaceKey,
+				Key:      ctrlmesh.NamespaceShardLabel(),
 				Operator: metav1.LabelSelectorOpNotIn,
 				Values:   canaryConfig.InNamespaces,
 			})
 		}
 		if canaryConfig != nil && len(canaryConfig.InShardHash) > 0 && *root.Spec.Root.Canary.Replicas > 0 {
 			newSel.Selector.MatchExpressions = append(newSel.Selector.MatchExpressions, metav1.LabelSelectorRequirement{
-				Key:      ctrlmesh.CtrlmeshShardHashKey,
+				Key:      ctrlmesh.ShardHashLabel(),
 				Operator: metav1.LabelSelectorOpNotIn,
 				Values:   canaryConfig.InShardHash,
 			})
 		}
 		newSel.Selector.MatchExpressions = append(newSel.Selector.MatchExpressions, metav1.LabelSelectorRequirement{
-			Key:      ctrlmesh.CtrlmeshShardHashKey,
+			Key:      ctrlmesh.ShardHashLabel(),
 			Operator: metav1.LabelSelectorOpIn,
 			Values:   batch,
 		})

--- a/pkg/webhook/ns/namespace_mutating_handler.go
+++ b/pkg/webhook/ns/namespace_mutating_handler.go
@@ -67,17 +67,17 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 func (h *MutatingHandler) shouldUpdateNs(ns *v1.Namespace) (shouldUpdate bool) {
 	shouldUpdate = false
-	if _, exist := ns.Labels[ctrlmesh.CtrlmeshControlKey]; !exist {
-		ns.Labels[ctrlmesh.CtrlmeshControlKey] = "true"
+	if _, exist := ns.Labels[ctrlmesh.MeshControlLabel()]; !exist {
+		ns.Labels[ctrlmesh.MeshControlLabel()] = "true"
 		shouldUpdate = true
 	}
-	if val, exist := ns.Labels[ctrlmesh.CtrlmeshNamespaceKey]; !exist || val != ns.Name {
-		ns.Labels[ctrlmesh.CtrlmeshNamespaceKey] = ns.Name
+	if val, exist := ns.Labels[ctrlmesh.NamespaceShardLabel()]; !exist || val != ns.Name {
+		ns.Labels[ctrlmesh.NamespaceShardLabel()] = ns.Name
 		shouldUpdate = true
 	}
 	nsHash := strconv.Itoa(rand.Hash(ns.Name, constants.DefaultShardingSize))
-	if val, exist := ns.Labels[ctrlmesh.CtrlmeshShardHashKey]; !exist || nsHash != val {
-		ns.Labels[ctrlmesh.CtrlmeshShardHashKey] = nsHash
+	if val, exist := ns.Labels[ctrlmesh.ShardHashLabel()]; !exist || nsHash != val {
+		ns.Labels[ctrlmesh.ShardHashLabel()] = nsHash
 		shouldUpdate = true
 	}
 	return shouldUpdate


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it:

1. Support label redefinition through flags: 
- `ctrlmesh.kusionstack.io/control`, the sharding hash label. 
- `ctrlmesh.kusionstack.io/shard-hash`, the controller-mesh control label. 
- `ctrlmesh.kusionstack.io/namespace`, the namespace label. 
2. Support disable patch runnable.

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->



## Special notes for your reviewer:

### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note

```

### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```